### PR TITLE
Handle empty markdown elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,12 @@ function getClassyFromBlockElement(tokens, idx, fullName) {
     }
   }
 
+  // In the case of empty markdown elements ("*" for example), there
+  // won't be any inline content, so in that case just return null
+  if (!(inlineContents && inlineContents.length)) {
+    return null;
+  }
+
   // if the last token of the inline content is of type "classy"
   // we have to do our thing
   if (inlineContents[inlineContents.length - 1].type !== "classy") {

--- a/test/classy.js
+++ b/test/classy.js
@@ -37,4 +37,7 @@ describe("markdown-it-classy", function () {
   it("should work with blockquotes", function () {
     md.render("> foo bar\n{baz}").should.containEql("<blockquote class=\"baz\">");
   });
+  it("should handle empty markdown elements", function () {
+    md.render("*").should.containEql("<ul>");
+  });
 });


### PR DESCRIPTION
markdown-it-classy currently throws an error when it encounters empty markdown elements. Here is a simple test case:

``` js
var md = require('markdown-it')();
var classy = require('markdown-it-classy');

var markdown = '*';

md.use(classy);
md.render(markdown);
```

This causes a TypeError on line 83 of index.js:

``` js
if (inlineContents[inlineContents.length - 1].type !== "classy") {
```

... since inlineContents is undefined if there is no inline content.

This PR adds a check for this, as well as a simple test case.
